### PR TITLE
fix: don't add props.style.transform twice

### DIFF
--- a/playground/src/react-interactable/InteractableView.js
+++ b/playground/src/react-interactable/InteractableView.js
@@ -93,9 +93,11 @@ export default function injectDependencies( Animated, PanResponder ){
 		render() {
 			let { x, y } = this.getAnimated()
 			let style = this.props.style
+			const styleWithoutTransform = { ...style }
+			delete styleWithoutTransform.transform
 			let withPosition = {
 				transform: [{ translateX: x }, { translateY: y }].concat( style.transform || [] ),
-				...style
+				...styleWithoutTransform
 			}
 
 			let panHandlers = this.props.dragEnabled ? this._pr.panHandlers : {}


### PR DESCRIPTION
this change allows setting transform style prop on InteractableView. Previously the transform prop was being added twice which broke the styles
- fix #4 
- [ ] add test